### PR TITLE
Refactor Consumer

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ $ kill -9 14381
 Tests can be run with:
 
 ```bash
-$ mix test
+$ mix test --no-start
 ```
 
 ## License

--- a/config/config.exs
+++ b/config/config.exs
@@ -9,4 +9,11 @@ config :porcelain,
 config :logger,
   level: :info
 
+config :rem,
+  commands: ~W[
+    ping
+    repo
+  ],
+  prefixes: ~W[! Rem]
+
 import_config "#{Mix.env()}.exs"

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,8 @@
+import Config
+
+config :nostrum,
+  token: "test_token"
+
+config :rem, Rem.Discord.Api, %{
+  inject: true
+}

--- a/lib/rem/commands/command.ex
+++ b/lib/rem/commands/command.ex
@@ -1,0 +1,11 @@
+defmodule Rem.Commands.Command do
+  @doc """
+  A command processes a command/request done to the bot.
+  All commands end in *Command for the sake of clarity.
+  """
+
+  alias Nostrum.Struct.Message
+
+  # NOTE: With only one method behavior may seem like an overkill...
+  @callback run(Message.t(), binary) :: :ok | :error
+end

--- a/lib/rem/commands/ping_command.ex
+++ b/lib/rem/commands/ping_command.ex
@@ -1,7 +1,7 @@
 defmodule Rem.Commands.PingCommand do
   @behaviour Rem.Commands.Command
 
-  alias Nostrum.Api
+  alias Rem.Discord.Api
 
   @impl true
   def run(%{channel_id: channel_id}, _args_str),

--- a/lib/rem/commands/ping_command.ex
+++ b/lib/rem/commands/ping_command.ex
@@ -1,0 +1,9 @@
+defmodule Rem.Commands.PingCommand do
+  @behaviour Rem.Commands.Command
+
+  alias Nostrum.Api
+
+  @impl true
+  def run(%{channel_id: channel_id}, _args_str),
+    do: Api.create_message(channel_id, "Still alive!")
+end

--- a/lib/rem/commands/repo_command.ex
+++ b/lib/rem/commands/repo_command.ex
@@ -1,0 +1,9 @@
+defmodule Rem.Commands.RepoCommand do
+  @behaviour Rem.Commands.Command
+
+  alias Nostrum.Api
+
+  @impl true
+  def run(%{channel_id: channel_id}, _args_str),
+    do: Api.create_message(channel_id, "https://github.com/pyzlnar/rem-bot")
+end

--- a/lib/rem/commands/repo_command.ex
+++ b/lib/rem/commands/repo_command.ex
@@ -1,7 +1,7 @@
 defmodule Rem.Commands.RepoCommand do
   @behaviour Rem.Commands.Command
 
-  alias Nostrum.Api
+  alias Rem.Discord.Api
 
   @impl true
   def run(%{channel_id: channel_id}, _args_str),

--- a/lib/rem/consumer/meta.ex
+++ b/lib/rem/consumer/meta.ex
@@ -1,0 +1,46 @@
+defmodule Rem.Consumer.Meta do
+  defmacro __using__(_) do
+    quote do
+      unquote(generate_extract_prefix())
+      unquote(generate_extract_command())
+    end
+  end
+
+  def generate_extract_prefix do
+    quote do
+      @spec extract_prefix(binary) :: {:ok, binary} | :error
+      unquote(generate_extract_prefix_from_config())
+
+      def extract_prefix(_other), do: :error
+    end
+  end
+
+  defp generate_extract_prefix_from_config do
+    for prefix <- Application.get_env(:rem, :prefixes, []) do
+      quote do
+        def extract_prefix(unquote(prefix) <> command), do: {:ok, String.trim(command)}
+      end
+    end
+  end
+
+  def generate_extract_command do
+    quote do
+      @spec extract_command(binary) :: {:ok, binary, list} |  :error
+      unquote(generate_extract_command_from_config())
+
+      def extract_command(_), do: :error
+    end
+  end
+
+  defp generate_extract_command_from_config do
+    for command <- Application.get_env(:rem, :commands, []) do
+      command_suffix = command |> String.capitalize |> Kernel.<>("Command")
+      command_alias  = Module.concat(Rem.Commands, command_suffix)
+
+      quote do
+        def extract_command(unquote(command) <> args),
+          do: {:ok, unquote(command_alias), String.trim(args)}
+      end
+    end
+  end
+end

--- a/lib/rem/consumer/meta.ex
+++ b/lib/rem/consumer/meta.ex
@@ -35,7 +35,7 @@ defmodule Rem.Consumer.Meta do
   defp generate_extract_command_from_config do
     for command <- Application.get_env(:rem, :commands, []) do
       command_suffix = command |> String.capitalize |> Kernel.<>("Command")
-      command_alias  = Module.concat(Rem.Commands, command_suffix)
+      command_alias  = Module.safe_concat(Rem.Commands, command_suffix)
 
       quote do
         def extract_command(unquote(command) <> args),

--- a/lib/rem/discord/api.ex
+++ b/lib/rem/discord/api.ex
@@ -1,0 +1,22 @@
+defmodule Rem.Discord.Api do
+  @moduledoc """
+  This module acts as a wrapper for Nostrum.Api
+  The sole purpose of this module is to be able to write tests
+  """
+
+  module = Nostrum.Api
+
+  for {name, arity} <- module.__info__(:functions) do
+    args = 1..arity |> Enum.map(& Macro.var(:"arg#{&1}", __MODULE__))
+
+    if Application.get_env(:rem, __MODULE__)[:inject] do
+      def unquote(name)(unquote_splicing(args)) do
+        Injector.inject(__MODULE__, unquote(name), unquote(args))
+      end
+    else
+      def unquote(name)(unquote_splicing(args)) do
+        apply(unquote(module), unquote(name), unquote(args))
+      end
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -6,6 +6,7 @@ defmodule Rem.MixProject do
       app: :rem,
       version: "0.1.0",
       elixir: "~> 1.13",
+      elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps()
     ]
@@ -18,6 +19,10 @@ defmodule Rem.MixProject do
       mod: {Rem.Application, []}
     ]
   end
+
+  # Load extra paths when on test
+  defp elixirc_paths(:test), do: ~W[lib test/support]
+  defp elixirc_paths(_), do: ~W[lib]
 
   # Run "mix help deps" to learn about dependencies.
   defp deps do

--- a/test/rem/commands/ping_command_test.exs
+++ b/test/rem/commands/ping_command_test.exs
@@ -1,0 +1,16 @@
+defmodule Rem.Commands.PingCommandTest do
+  use ExUnit.Case, async: true
+  use Injector, inject: [Rem.Discord.Api]
+
+  alias Rem.Commands.PingCommand
+
+  describe "run/2" do
+    test "returns a message stating the bot still lives" do
+
+      Rem.Discord.Api
+      |> expects(:create_message, fn 123456, "Still alive!" -> :ok end)
+
+      assert :ok = PingCommand.run(%{channel_id: 123456}, "")
+    end
+  end
+end

--- a/test/rem/commands/repo_command_test.exs
+++ b/test/rem/commands/repo_command_test.exs
@@ -1,0 +1,16 @@
+defmodule Rem.Commands.RepoCommandTest do
+  use ExUnit.Case, async: true
+  use Injector, inject: [Rem.Discord.Api]
+
+  alias Rem.Commands.RepoCommand
+
+  describe "run/2" do
+    test "returns a message stating the bot still lives" do
+
+      Rem.Discord.Api
+      |> expects(:create_message, fn 123456, "https://github.com/pyzlnar/rem-bot" -> :ok end)
+
+      assert :ok = RepoCommand.run(%{channel_id: 123456}, "")
+    end
+  end
+end

--- a/test/rem/consumer_test.exs
+++ b/test/rem/consumer_test.exs
@@ -1,0 +1,43 @@
+defmodule Rem.ConsumerTest do
+  use ExUnit.Case, async: true
+
+  alias Rem.Consumer
+
+  describe "extract_prefix/1" do
+    test "removes the prefix and returns the rest of the string"  do
+      assert {:ok, "ping"}            = Consumer.extract_prefix("!ping")
+      assert {:ok, "unknown_command"} = Consumer.extract_prefix("!unknown_command")
+      assert {:ok, "ping other args"} = Consumer.extract_prefix("!ping other args")
+      assert {:ok, "ping with space"} = Consumer.extract_prefix("! ping with space")
+    end
+
+    test "returns {:ok, rest} for all valid prefixes" do
+      Application.get_env(:rem, :prefixes, [])
+      |> Enum.each(fn prefix ->
+        assert {:ok, _rest} = Consumer.extract_prefix(prefix <> "command")
+      end)
+    end
+
+    test "returns error for unknown prefixes" do
+      assert :error = Consumer.extract_prefix("no_prefix ping")
+    end
+  end
+
+  describe "extract_command/1" do
+    test "removes the command and returns the command and a string with the remaining args" do
+      assert {:ok, Rem.Commands.PingCommand, ""}           = Consumer.extract_command("ping")
+      assert {:ok, Rem.Commands.PingCommand, "other args"} = Consumer.extract_command("ping other args")
+    end
+
+    test "returns {:ok, rest} for all valid commands" do
+      Application.get_env(:rem, :commands, [])
+      |> Enum.each(fn command ->
+        assert {:ok, _command, _args} = Consumer.extract_command(command <> "other args")
+      end)
+    end
+
+    test "returns error for unknown commands" do
+      assert :error = Consumer.extract_command("unknown_command")
+    end
+  end
+end

--- a/test/support/injector.ex
+++ b/test/support/injector.ex
@@ -1,0 +1,75 @@
+defmodule Injector do
+  alias Injector.{ExpectationError, Server}
+
+  # --- Meta --- #
+
+  defmacro __using__(opts) do
+    injectors = Keyword.get(opts, :inject, [])
+    quote do
+      import unquote(__MODULE__), only: [stubs: 3, expects: 3, expects: 4]
+
+      setup_all do
+        servers =
+          for injector <- unquote(injectors), into: %{} do
+            {:ok, server} = start_supervised(Injector.Server)
+            {injector, server}
+          end
+
+        %{injectors: servers}
+      end
+
+      setup %{injectors: servers} = context do
+        Process.put(:injectors, servers)
+        on_exit(fn ->
+          Process.delete(:injectors)
+          Enum.each(servers, &unquote(__MODULE__).ended/1)
+        end)
+        context
+      end
+    end
+  end
+
+
+  # --- Api --- #
+
+  def expects(server, fn_name, times \\ 1, fun) do
+    Server.expects(get_server(server), fn_name, times, fun)
+  end
+
+  def stubs(server, fn_name, fun) do
+    Server.stubs(get_server(server), fn_name, fun)
+  end
+
+  def inject(server, fn_name, args) do
+    case Server.called(get_server(server), fn_name, args) do
+      {:ok, result} ->
+        result
+      {:error, msg} ->
+        raise msg
+      _ ->
+        raise "There was an error calling #{fn_name}"
+    end
+  end
+
+  def ended({_mod, server}) do
+    case Server.ended(get_server(server)) do
+      :ok ->
+        :ok
+      {:errors, [first_error|_]} ->
+        raise ExpectationError, message: first_error
+      _ ->
+        raise "ONOZ"
+
+    end
+  end
+
+  # --- Helpers --- #
+
+  def get_server(server) when is_pid(server) do
+    server
+  end
+
+  def get_server(server) when is_atom(server) do
+    Process.get(:injectors)[server]
+  end
+end

--- a/test/support/injector/expectation_error.ex
+++ b/test/support/injector/expectation_error.ex
@@ -1,0 +1,3 @@
+defmodule Injector.ExpectationError do
+  defexception message: "A function was expected to be called a certain number of times, but wasn't"
+end

--- a/test/support/injector/server.ex
+++ b/test/support/injector/server.ex
@@ -1,0 +1,119 @@
+defmodule Injector.Server do
+  use GenServer
+  import GenServer, only: [call: 2]
+
+  # --- Startup --- #
+
+  def start_link(_) do
+    GenServer.start_link(__MODULE__, %{})
+  end
+
+  # --- API --- #
+
+  def expects(server, name, times \\ 1, fun) do
+    call(server, {:register, name, times, fun})
+  end
+
+  def stubs(server, name, fun) do
+    call(server, {:register, name, :infinite, fun})
+  end
+
+  def called(server, name, args) do
+    call(server, {:called, name, args})
+  end
+
+  def ended(server) do
+    call(server, :ended)
+  end
+
+  # --- Server --- #
+
+  def init(state),
+    do: {:ok, state}
+
+  def handle_call({:register, name, :infinite, fun}, _from, state) do
+    state = Map.put(state, name, %{function: fun})
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:register, name, times, fun}, _from, state) do
+    state = Map.put(state, name, %{function: fun, times: times, called: 0})
+    {:reply, :ok, state}
+  end
+
+  def handle_call({:called, name, args}, _from, state) do
+    with {:ok, register} <- get_registered_function(state, name),
+         {:ok, result}   <- safely_call_function(register, args),
+         register        <- get_new_register(register)
+    do
+      state = Map.put(state, name, register)
+      {:reply, {:ok, result}, state}
+    else
+      {:error, _} = reply ->
+        {:reply, reply, state}
+      other ->
+        {:reply, {:error, "There was an error:\n#{inspect(other)}"}, state}
+    end
+  end
+
+  def handle_call(:ended, _from, state) do
+    reply = all_expectations_called?(state)
+
+    {:reply, reply, %{}}
+  end
+
+  # --- Helpers --- #
+
+  def get_registered_function(state, name) do
+    case state[name] do
+      nil ->
+        {:error, "Function '#{name}' was called but a stub not been registered"}
+      register ->
+        {:ok, register}
+    end
+  end
+
+  def safely_call_function(%{function: fun}, args) do
+    try do
+      result = apply(fun, args)
+      {:ok, result}
+    rescue
+      error ->
+        case error do
+          %{message: message} ->
+            {:error, message}
+          other ->
+            {:error, other}
+        end
+    end
+  end
+
+  def get_new_register(%{times: _, called: _} = register) do
+    %{register| called: register.called + 1}
+  end
+
+  def get_new_register(register) do
+    register
+  end
+
+  def all_expectations_called?(state) do
+    case Enum.reject(state, &expectation_complete?/1) do
+      [] ->
+        :ok
+      failed_expectations  ->
+        errors = Enum.map(failed_expectations, &expectation_to_error/1)
+        {:errors, errors}
+    end
+  end
+
+  def expectation_complete?({_, %{times: times, called: called}}) when times != called, do: false
+  def expectation_complete?(_), do: true
+
+  def expectation_to_error({name, %{times: times, called: 0}}) do
+    "Function #{name} was expected to be called #{times} times, but was not called."
+  end
+
+  def expectation_to_error({name, %{times: times, called: called}}) do
+    "Function #{name} was expected to be called #{times} times, but was called #{called} times."
+  end
+end


### PR DESCRIPTION
- Moved business logic to their own files
- Prefixes and Commands checks are now auto generated with meta
- Added tests for Consumer, PingCommand and RepoCommand