### PR TITLE
Bug: Fixed Nostrum gateway intents

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,7 +1,13 @@
 import Config
 
 config :nostrum,
-  token: System.get_env("DISCORD_TOKEN", "discord_token_missing")
+  token: System.get_env("DISCORD_TOKEN", "discord_token_missing"),
+  gateway_intents: ~W[
+    guilds
+    guild_messages
+    direct_messages
+    message_content
+  ]a
 
 config :logger,
   level: :info


### PR DESCRIPTION
Probably something added in the update, since message content is no longer enabled by default.
It passed unnnoticed because I was only using the bot on DMs which don't need said permission. lol